### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 .externalNativeBuild
 /.idea
 .idea
+app/src/main/res/audio


### PR DESCRIPTION
removed "/" in /app/src/main/res/audio to eliminate confusion in the root of the drive